### PR TITLE
Fix request path

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,11 +17,11 @@ class ApplicationController < ActionController::Base # :nodoc:
     template << "." + params[:format] if params[:format].present?
 
     if template.index(absolute_root) == 0
-      if File.directory?(template) and /\/\z/ !~ request.fullpath
-        return redirect_to(request.fullpath + "/")
+      if File.directory?(template) and /\/\z/ !~ request.original_fullpath
+        return redirect_to(request.original_fullpath + "/")
       end
 
-      if /\/\z/ =~ request.fullpath
+      if /\/\z/ =~ request.original_fullpath
         ['.html.erb', '.erb', '.rhtml', '.html'].each do |ext|
           if File.file?(template+'/index'+ ext)
             template = template + '/index' + ext


### PR DESCRIPTION
app/controller/application_controller.rb の rescue_404 メソッドにおいて，リクエストURLを `request.fullpath` で取得していた．
しかし，`request.fullpath` ではリクエストURLの最後の `/` が取り除かれたものが取得されており，この結果，rescue_404 メソッド内の処理の一部が正常に動作していなかった．
そこで，`request.fullpath` を `request.original_fullpath` に変更し，リクエストURLの最後の `/` を取得できるようにした．
