### PR TITLE
Change authentication flow

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,7 @@ class ApplicationController < ActionController::Base # :nodoc:
   # scope_parameter_logging :password
   prepend_before_filter :login_state_setup
   before_filter :authenticate, except: :rescue_404
+  before_filter :is_user_named?, except: :rescue_404
 
   def rescue_404
     absolute_root = File.join(File.expand_path(Rails.root), '')
@@ -84,6 +85,14 @@ class ApplicationController < ActionController::Base # :nodoc:
 
     session[:jumpto] = request.parameters
     redirect_to :controller => "gate", :action => "login"
+    return false
+  end
+
+  def is_user_named?
+    return true if User.current.nil? || User.current.ident
+
+    flash[:warning] = "Set up your nickname."
+    redirect_to :controller => "users", :action => "edit"
     return false
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,7 @@
 class UsersController < ApplicationController
   before_action :set_user, only: [:show, :update, :destroy, :change_password]
   before_filter :authenticate
+  skip_before_filter :is_user_named?
 
   # GET /users
   # GET /users.json
@@ -46,13 +47,13 @@ class UsersController < ApplicationController
       if @user.update(user_params)
         format.html {
           flash[:info] = 'Successfully updated.'
-          redirect_to root_path + "settings"
+          render :edit
         }
         format.json { render :show, status: :ok, location: @user }
       else
         format.html {
           flash[:danger] = 'Updating was failed.'
-          render root_path + "settings"
+          render :edit
         }
         format.json { render json: @user.errors, status: :unprocessable_entity }
       end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,8 +6,6 @@ class User < ActiveRecord::Base
 
   validates_uniqueness_of :ident
 
-  validates_format_of :ident, :with => /\A[a-zA-Z\d]+(-[a-zA-Z\d]+)*\z/
-
   def self.current=(user)
     @current_user = user
   end
@@ -51,5 +49,9 @@ class User < ActiveRecord::Base
       uid:        auth["uid"],
       avatar_url: auth["info"]["image"]
     )
+  end
+
+  def is_associated?
+    provider && uid
   end
 end

--- a/app/views/gate/index.html
+++ b/app/views/gate/index.html
@@ -1,6 +1,0 @@
-<dl>
-  <dt><a href="/gate/login">BASIC authentication</a></dt>
-  <dd>アカウントがすでにあるがOmniAuthを設定していない方はこちら．</dd>
-  <dt><a href="/auth/github">OmniAuth</a></dt>
-  <dd>GitHubアカウントでアカウントを新規作成する方やOmniAuthを設定した方はこちら．</dd>
-</dl>

--- a/app/views/gate/login.html.erb
+++ b/app/views/gate/login.html.erb
@@ -1,17 +1,14 @@
-<%= form_tag do %>
-  <table>
-    <tr>
-    <td>Login name:</td>
-    <td><%= text_field_tag "ident" %></td>
-    </tr>
-
-    <tr>
-      <td>Password:</td>
-      <td><%= password_field_tag "password" %></td>
-    </tr>
-
-    <tr>
-      <td></td>
-     <td><%= submit_tag "LOGIN" %></td>
-  </table>
-<% end %>
+<div class="col-md-4" >
+  <%= form_tag do %>
+    <div class="form-group">
+      <label>Nickname</label>
+      <%= text_field_tag "ident", "", class: "form-control" %>
+    </div>
+    <div class="form-group">
+      <label>Password</label>
+      <%= password_field_tag "password", "", class: "form-control" %>
+    </div>
+    <%= submit_tag "Log in", class: "btn btn-default" %>
+  <% end %>
+  <%= button_to "Log in with GitHub", "/auth/github", class: "btn btn-default" %>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -74,7 +74,7 @@
    </div>
     <div class="container">
      <footer>
-      <%= link_to "Nomura Laboratory (c)", {:controller => "gate", :action => "index"}, :class => "unclear-link" %>
+      <%= link_to "Nomura Laboratory (c)", {:controller => "gate", :action => "login"}, :class => "unclear-link" %>
      </footer>
     </div>
   </body>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -3,9 +3,9 @@
   <div class="box setting-box">
     <h2>Change ident</h2>
     <%= form_tag root_path + "users/#{@user.id}", {method: :put} do %>
-      <label>ident</label>
+      <label>nickname</label>
       <%= text_field :user, :ident, class: "form-control" %>
-      <%= button_tag "Change ident", class: "btn btn-default" %>
+      <%= button_tag "Change nickname", class: "btn btn-default" %>
     <% end %>
   </div>
   <div class="box">
@@ -22,7 +22,7 @@
   </div>
   <div class="box">
     <h2>Setting OmniAuth</h2>
-    <% unless @user.uid %>
+    <% unless @user.is_associated? %>
       <%= button_to "Associate with GitHub", root_path + "auth/github", class: "btn btn-default" %>
     <% else %>
       Your account is already associated with GitHub.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,8 +11,7 @@ Rails.application.routes.draw do
   put 'users/:id/change_password', to: 'users#change_password'
   resources :users, except: :edit
 
-  get "gate/index"
-  get "/auth/:provider/callback", to: "gate#login"
+  get "/auth/:provider/callback", to: "gate#omniauth"
   match "gate/login", :via => [:get, :post]
   get "gate/logout"
   get '*path', to: 'application#rescue_404'


### PR DESCRIPTION
- 挙動1（現役）
  - Nomura Laboratory (c)をクリック
  - GitHubでログインボタンを押下
  - ログイン成功
- 挙動1'（現役かつGitHubのアカウント関連付け未完了）
  - Nomura Laboratory (c)をクリック
  - ニックネームとパスワードを入力して通常のログインボタンを押下
  - ログイン成功
  - 設定ページからGitHubアカウントとの関連付けが可能
- 挙動2（新B4）
  - Nomura Laboratory (c)をクリック
  - GitHubでログインボタンを押下
  - 一時的なアカウントでログイン成功（identは空のユーザ）
    - identが空のユーザはノムニチでアカウントを作る権利のみ有する
    - アカウント作成ページに飛ばす．（before_actionも忘れずに）
  - ニックネームを入力させる
  - アカウント作成完了
- 挙動3（OP）
  - Nomura Laboratory (c)をクリック
  - ニックネームとパスワードを入力して通常のログインボタンを押下
  - ログイン成功
  - 設定ページからGitHubアカウントとの関連付けが可能
- 挙動4（外部）
  - Nomura Laboratory (c)をクリック
  - ニックネームとパスワードを入力して通常のログインボタンを押下
  - ログイン失敗
  - GitHubでログインボタンを押下
  - ログイン失敗
