### PR TITLE
Change link to article page in top page into english

### DIFF
--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -36,5 +36,7 @@
   </div>
   <p></p>
   <%= render partial: "articles/card", collection: @headline, as: :article %>
-  <%= link_to "(もっと読む)", articles_path %>
+  <%= link_to articles_path do %>
+    <%= fa_icon "newspaper-o" %> More Articles
+  <% end %>
 </div>


### PR DESCRIPTION
各記事の”続きを読む”からアイコン＋”Read More”への変更に合わせて，
トップページから記事一覧へのリンクを”もっと読む”からアイコン＋"More Articles"に変更した．
