### PR TITLE
Add link which deletes a article to show

### DIFF
--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -25,9 +25,14 @@
       <hr>
 
       <% unless User.current.nil? %>
-       <div class="article-info">
-        <%= link_to '編集', edit_article_path(@article) %>
-       </div>
+        <div class="article-info">
+          <%= link_to edit_article_path(@article) do %>
+            <%= fa_icon "pencil" %>
+          <% end %>
+          <%= link_to article_path(@article), method: :delete, data: {confirm: 'Are you sure?'} do %>
+            <%= fa_icon "trash" %>
+          <% end %>
+        </div>
       <% end %>
 
       <div class="clear">


### PR DESCRIPTION
#55 に対する PR である．

ノムニチのshowページに削除リンクを追加した．削除リンクはノムニチにログインした状態で記事を閲覧するときのみ表示される．
また，削除リンクと編集リンクをアイコン化した．
![2015-11-13 14 08 03](https://cloud.githubusercontent.com/assets/11749705/11139204/024117f6-8a10-11e5-91c6-2609867db81e.png)
