### PR TITLE
Fix width of article form

### DIFF
--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -49,7 +49,7 @@
   <div class="field form-group">
     <div class="tab-content">
       <div class="tab-pane active" id="write" role="tabpanel">
-	<%= f.text_area :content, :rows => 20, :wrap => :off %>
+	<%= f.text_area :content, class: "form-control", rows: 20, wrap: :off %>
       </div>
       <div class="tab-pane preview_area" id="preview" role="tabpanel">
       </div>


### PR DESCRIPTION
#53 のPR中のコミット( https://github.com/ichikawa85/nomnichi/commit/7985f051666212d88be1cc14da35ec9e2c4172c0 )により，記事編集フォームのtext_areaから`class: "form-control"`が失われており，フォームの横幅が100%にならなくなっていた．
このため，text_areaに`class: "form-control"`を追加し，横幅が100%になるようにした．