### PR TITLE
Fix mistaken link for searching articles

### DIFF
--- a/app/views/articles/_side_bar.html.erb
+++ b/app/views/articles/_side_bar.html.erb
@@ -1,5 +1,5 @@
 <div class="side_bar">
-  <%= form_tag '/articles/search', method: 'GET' do %>
+  <%= form_tag articles_search_path, method: 'GET' do %>
     <div class="input-group" id="search-article">
       <%= text_field_tag :query, nil, class: "form-control", placeholder: "Search Articles" %>
       <span class="input-group-btn">


### PR DESCRIPTION
Now, Not link to relative URL root.
Therefore, change link for searching articles to following,

  Before: form_tag '/articles/search', ...
  After : form_tag articles_search_path, ...