### PR TITLE
Fix bug about archive of January, February, and March display

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -108,10 +108,10 @@ class ArticlesController < ApplicationController
   end
 
   def archive
-    year = params[:year].to_i
-    month = params[:month].to_i
+    year = params[:param].split("/")[0].to_i
+    month = params[:param].split("/")[1].to_i
 
-    if params[:month] != nil
+    if month != nil
       start_time = DateTime.new(year, month, 1)
       end_time = (start_time >> 1) - Rational(1, 24 * 60 * 60)
     else

--- a/app/helpers/articles_helper.rb
+++ b/app/helpers/articles_helper.rb
@@ -34,20 +34,23 @@ module ArticlesHelper
       end_time = DateTime.new(year + 1, 3, 31, 23, 59, 59, 99)
       item = articles.where("created_at >= ? and created_at <= ?", start_time, end_time)
       item = item.where("approved = ?", true) unless User.current
-      year_archives << {:year => "#{start_time.year}", :item => item.length, :month => list_month_archives(item)} unless item.empty?
+      year_archives << {:year => "#{start_time.year}", :item => item.length, :month => list_month_archives(item, start_time.year)} unless item.empty?
     end
     year_archives.select
   end
 
-  def list_month_archives(articles)
+  def list_month_archives(articles, year)
     month_archives = []
-    year = articles.first.created_at.year
     newest_month = articles.first.created_at.month
     oldest_month = articles.last.created_at.month
     ["04","05","06","07","08","09","10","11","12","01","02","03"].each do |month|
       item = articles.where("strftime('%m',created_at) = ?",month)
       item = item.where("approved = ?", true) unless User.current
-      month_archives << {:month => "#{month}", :item => item.length}
+      if ["01", "02", "03"].include?(month)
+        month_archives << {:month => "#{month}", :item => item.length, :param => (year + 1).to_s + "/" + month}
+      else
+        month_archives << {:month => "#{month}", :item => item.length, :param => year.to_s + "/" + month}
+      end
     end
     month_archives.select {|month| month[:item] != 0}
   end

--- a/app/views/articles/_side_bar.html.erb
+++ b/app/views/articles/_side_bar.html.erb
@@ -13,17 +13,17 @@
   <hr class="border">
   <% comments.each do |comment| %>
     <p class="comment-article-title"><%= link_to_article_by_perma_link(comment.article.title, comment.article) %></p>
-    <p class="comment-body">> <%= fold_comment(comment.body) %></p>
+    <p class="comment-body"> <%= fold_comment(comment.body) %></p>
     <p class="comment-name">by <%= comment.user.ident %></p>
   <% end %>
   <h5 class="side-title">Archives</h5>
   <hr class="border">
   <ul class="yearly">
     <% list_year_archives(articles).each do |year| %>
-      <li><%= link_to "#{year[:year]}年度(#{year[:item]})", controller: "articles", action: "archive", year: year[:year]%>
+      <li><%= link_to "#{year[:year]}年度(#{year[:item]})", controller: "articles", action: "archive", param: year[:year]%>
         <ul>
           <% year[:month].each do |month| %>
-            <li><%= link_to("#{month[:month]}月(#{month[:item]})", controller: "articles", action: "archive", year: year[:year], month: month[:month]) %></li>
+            <li><%= link_to("#{month[:month]}月(#{month[:item]})", controller: "articles", action: "archive", param: month[:param]) %></li>
           <% end %>
         </ul>
       </li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
   resources :articles, except: :show
   get 'articles/search'
   get 'articles/:perma_link', to: 'articles#show'
-  get 'articles/archive/:year(/:month)', to: 'articles#archive'
+  get 'articles/archive/:param', to: 'articles#archive'
   resources :comments
   resources :articles
   get 'settings', to:  'users#edit'


### PR DESCRIPTION
1月，2月，3月のアーカイブ表示に関するバグを修正した．

対象のアーカイブを選択すると1年前のアーカイブが取得される．
具体的には，2015年度1月のアーカイブを選択すると2014年度1月の記事が取得される．

これは記事取得時のパラメータの設定ミスによって起きていた．
アーカイブは年度ごとにまとめおり，2015年度1月のアーカイブを取得するためには，2016年1月で記事を取得しなければならない．
しかし，このとき，2015年1月で記事を取得していた．

よってこれを修正した．
また，コード自体リファクタリングする必要があるため，今回は応急処置として対処した．