### PR TITLE
Update the page of the research with Prof Okamoto

### DIFF
--- a/public_html/research/other/index.html
+++ b/public_html/research/other/index.html
@@ -25,7 +25,8 @@
     <ul>
       <li> <a href="http://www.cc.okayama-u.ac.jp/~okamot-a/okamoto.html">岡山大学経済学部 岡本章 教授</a>（研究代表者）
       <li> 乃村能成 准教授（研究分担者）
-      <li> <a href="../../users/kitagaki/index.html">北垣千拡 乃村研M2</a>（ソフトウェア開発）
+      <li> <a href="../../users/emi/index.html">江見圭祐</a> 乃村研 M1 (ソフトウェア開発)
+      <li> <a href="../../users/kitagaki/index.html">北垣千拡</a> 乃村研 2015年度修了（ソフトウェア開発）
     </ul>
   </p>
   <div class="clear"></div>


### PR DESCRIPTION
経済学部との共同研究のページを最新版に更新した．
具体的には，以下の2点を更新した．
- ソフトウェア開発担当として江見の項目を追加
- 前ソフトウェア開発担当者である北垣の項目に修了年度を記載
