### PR TITLE
Call authentication if not logged in and trying to view private article

### DIFF
--- a/app/helpers/articles_helper.rb
+++ b/app/helpers/articles_helper.rb
@@ -8,7 +8,7 @@ module ArticlesHelper
   end
 
   def list_headline(nth)
-    Article.where(promote_headline: true).order("published_on desc").slice(0..nth)
+    Article.visible.where(promote_headline: true).order("published_on desc").slice(0..nth)
   end
 
   def link_to_article_by_perma_link(str, article, option = {})

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -8,7 +8,7 @@ class Article < ActiveRecord::Base
 
   paginates_per 10
 
-  default_scope { order("published_on desc").visible }
+  default_scope { order("published_on desc") }
   scope :visible, -> { User.login? ? Article.all : Article.approved }
   scope :approved, -> { where("approved = ?", true) }
   scope :search, ->(query) {


### PR DESCRIPTION
 #104 に対するPRである．
未ログイン時に非公開記事のURLを踏むと，ログインフォームに遷移するようにした．

未ログイン状態の際，本PR以前の実装ではdefault_scopeにより記事がフィルタリングされ，非公開記事を取得できなかった．このため，未ログイン時に非公開の記事を参照できず，ログインフォームへ遷移できなかった．
そこで，本PRではdefault_scopeで記事をフィルタリングせず，記事全体に対して検索をかける処理の中で必要に応じてフィルタリングするように変更した．

また，上記の変更にともない，default_scopeによってフィルタリングされた記事を使用していた以下の機能も修正した．
(1) 記事の一覧機能
(2) 記事の閲覧機能
(3) トップページの人気記事表示機能

ログイン/非ログインのそれぞれの状態で以下の操作を行い，目的通り動作することを確認した．
(1) トップページを参照
(2) 記事一覧ページを参照
(3) 記事の検索機能を使って公開/非公開の記事をそれぞれ検索
(4) 公開/非公開の記事をそれぞれURLから参照