### PR TITLE
Specify GFM to article format by "default"

### DIFF
--- a/app/assets/javascripts/articles.coffee
+++ b/app/assets/javascripts/articles.coffee
@@ -187,7 +187,9 @@ renderMarkdown = (text, update_element, linenum) ->
 setupRenderPreviewButton = (selector) ->
   $(selector).on 'click', (e) ->
     previewArea = $(".preview_area")
+    user_id = $('#article_user_id').val()
     title = $('#article_title').val()
+    perma_link = $('#article_perma_link').val()
     content = $('#article_content').val()
     format = $('#article_format').val()
     $. ajax
@@ -197,7 +199,9 @@ setupRenderPreviewButton = (selector) ->
       dataType:  "html"
       data:
         article:
+          user_id: user_id
           title: title
+          perma_link: perma_link
           content: content
           format: format
       success: (html, status, xhr) ->

--- a/app/assets/javascripts/articles.coffee
+++ b/app/assets/javascripts/articles.coffee
@@ -189,6 +189,7 @@ setupRenderPreviewButton = (selector) ->
     previewArea = $(".preview_area")
     title = $('#article_title').val()
     content = $('#article_content').val()
+    format = $('#article_format').val()
     $. ajax
       async:     true
       type:      "POST"
@@ -198,6 +199,7 @@ setupRenderPreviewButton = (selector) ->
         article:
           title: title
           content: content
+          format: format
       success: (html, status, xhr) ->
         previewArea.empty()
         previewArea.append(html)

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -48,6 +48,7 @@ class ArticlesController < ApplicationController
     @article.perma_link = User.current.ident + "-" + Time.now.to_s(:perma_link)
     @article.user_id = User.current.id
     @article.published_on = Time.now
+    @article.format = "GFM"
   end
 
   # GET /articles/1/edit
@@ -106,7 +107,7 @@ class ArticlesController < ApplicationController
     clear = "<div class='clear'></div>"
 
     render text: title + Kramdown::Document.new(article_params[:content],
-                                                input: "GFM",
+                                                input: article_params[:format],
                                                 syntax_highlighter: :rouge,
                                                 syntax_highlighter_opts: {css_class: 'highlight'}
                                                ).to_html + clear
@@ -157,7 +158,7 @@ class ArticlesController < ApplicationController
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def article_params
-    params.require(:article).permit(:user_id, :title, :perma_link, :content, :published_on, :approved, :count, :promote_headline)
+    params.require(:article).permit(:user_id, :title, :perma_link, :content, :published_on, :approved, :count, :promote_headline, :format)
   end
 
   #count up the number of view

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -96,21 +96,25 @@ class ArticlesController < ApplicationController
   end
 
   def preview
-    title =
-      """
-      <div class='title-bar'>
-        <span class='title'>
-          #{article_params[:title]}
-        </span>
-      </div>
-      """
-    clear = "<div class='clear'></div>"
+    if Article.new(article_params).invalid?(:except_preview)
+      render text: "Bad request", status: 400
+    else
+      title =
+        """
+        <div class='title-bar'>
+          <span class='title'>
+            #{article_params[:title]}
+          </span>
+        </div>
+        """
+      clear = "<div class='clear'></div>"
 
-    render text: title + Kramdown::Document.new(article_params[:content],
-                                                input: article_params[:format],
-                                                syntax_highlighter: :rouge,
-                                                syntax_highlighter_opts: {css_class: 'highlight'}
-                                               ).to_html + clear
+      render text: title + Kramdown::Document.new(article_params[:content],
+                                                  input: article_params[:format],
+                                                  syntax_highlighter: :rouge,
+                                                  syntax_highlighter_opts: {css_class: 'highlight'}
+                                                 ).to_html + clear
+    end
 
   end
 

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -4,7 +4,8 @@ class Article < ActiveRecord::Base
 
   validates :user_id, presence: true
   validates :title, presence: true
-  validates :perma_link, presence: true, uniqueness: true
+  validates :perma_link, presence: true, uniqueness: true, unless: proc { [:except_preview].include?(validation_context) }
+  validates :format, presence: true, inclusion: {in: ["Kramdown", "GFM"]}
 
   paginates_per 10
 

--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -12,6 +12,7 @@
   <% end %>
 
   <%= f.hidden_field :user_id %>
+  <%= f.hidden_field :format %>
 
   <div class="field form-group">
     <%= f.label :title %><br>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -17,7 +17,7 @@
 
       <div class="content">
         <%= raw Kramdown::Document.new(@article.content,
-                                       input: "GFM",
+                                       input: @article.format,
                                        syntax_highlighter: :rouge,
                                        syntax_highlighter_opts: {css_class: 'highlight'}
                                        ).to_html %>

--- a/db/migrate/20160930052633_add_format_to_articles.rb
+++ b/db/migrate/20160930052633_add_format_to_articles.rb
@@ -1,0 +1,5 @@
+class AddFormatToArticles < ActiveRecord::Migration
+  def change
+    add_column :articles, :format, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151021042053) do
+ActiveRecord::Schema.define(version: 20160930052633) do
 
   create_table "articles", force: :cascade do |t|
     t.integer  "user_id"
@@ -24,6 +24,7 @@ ActiveRecord::Schema.define(version: 20151021042053) do
     t.boolean  "promote_headline"
     t.datetime "created_at",                   null: false
     t.datetime "updated_at",                   null: false
+    t.string   "format"
   end
 
   add_index "articles", ["perma_link"], name: "index_articles_on_perma_link", unique: true


### PR DESCRIPTION
#112 に対する PR である．

Article モデルに記事の記法を示す format カラムを追加した．
format に記法を指定しておくことで，記事を表示する際に指定した記法が適用される．
また，記法を選択するインタフェースは用意しておらず，
現在は，デフォルトで GFM が指定される．
#112 を解決するためには，

本 PR が merge された後に，既存の記事の format に "Kramdown" を指定する必要がある．
