### PR TITLE
Add systemd config file

### DIFF
--- a/systemd_conf/user/nomnichi.service
+++ b/systemd_conf/user/nomnichi.service
@@ -1,0 +1,15 @@
+[Unit]
+Description = Nomura Laboratory's Blog System
+# Show more detail in https://github.com/nomlab/nomnichi
+
+[Service]
+# Please change WorkingDirectory and EnviromentFile paths to suit your environment.
+WorkingDirectory=/home/nomlab/nomnichi
+EnvironmentFile=/home/nomlab/.config/systemd/user/nomnichi_env
+
+ExecStart=/bin/sh -c 'exec ./bin/server.sh start pro >> ./nomnichi.log 2>&1'
+Type=forking
+Restart=on-failure
+
+[Install]
+WantedBy=default.target

--- a/systemd_conf/user/nomnichi_env
+++ b/systemd_conf/user/nomnichi_env
@@ -1,0 +1,3 @@
+# This is nomnichi's environment file
+# Please change PATH to suit your environment.
+PATH=/home/nomlab/.rbenv/shims:/usr/bin:/bin


### PR DESCRIPTION
#148 へのPR
+ デーモンとして起動できるように，systemd の設定ファイルをに追加した．
+ ログは nomnichi/nomnichi.log に出力
+ 以下のコマンドで設定

```
$ cp systemd_conf/user/* $HOME/.config/systemd/user/
$ systemctl --user enable nomnichi.service
$ systemctl --user start nomnichi.service
```
### nomnichi.serviceについて
+ 11行目のTypeをforkingにすることで，子プロセスが終了しないようにした．
  + https://unix.stackexchange.com/questions/442575/how-do-i-figure-out-why-my-systemctl-service-didnt-start-on-centos-7