### PR TITLE
Add yamada-k's profile

### DIFF
--- a/public_html/users/yamada-k/index.html
+++ b/public_html/users/yamada-k/index.html
@@ -1,0 +1,29 @@
+<h2>山田 敬汰</h2>
+<hr>
+<dl>
+  <dt>所属 :</dt>
+  <dd>
+    <a href="https://www.okayama-u.ac.jp/">岡山大学</a>
+    <a href="https://www.eng.okayama-u.ac.jp/it/">工学部情報系学科</a>
+    <a href="http://www.swlab.cs.okayama-u.ac.jp/lab/nom">乃村研究室</a>
+  </dd>
+</dl>
+<hr>
+<h3>履歴</h3>
+<ul>
+  <li>2018年（平成30年）岡山県立倉敷天城高校卒業</li>
+  <li>2018年（平成30年）岡山大学工学部情報系学科入学</li>
+</ul>
+<hl>
+<h4>SNS</h4>
+<ul>
+  <li>Twitter -  <a href="https://twitter.com/keita_developer">@keita_developer</a></li>
+  <li>Github - <a href="https://github.com/ymdkit">@ymdkit</a></li>
+</ul>
+<h4>技術領域</h4>
+<ul>
+  <li>Kotlin - Androidアプリ開発のために習得．</li>
+  <li>Swift - iOSアプリ開発のために習得．</li>
+  <li>JavaScript(TypeScript) - Webサービス開発のために習得．主な使用フレームワークは <a href="https://nextjs.org/">Next.js</a>．</li>
+  <li>PHP - Webサービス開発のために習得．主な使用フレームワークは <a href="https://laravel.com/">Laravel</a>．</li>
+</ul>


### PR DESCRIPTION
## TL;DR

- 山田敬汰のプロフィールページを追加

## 実装目的

- 乃村研のgit勉強会の課題に取り組むため

## 実装内容

- 構成員一覧ページに「山田敬汰」を追加
- 「山田敬汰」のプロフィール画面を新規作成

## その他

- 新たに「SNS」「技術領域」といったセクションを追加してみたのですが，いかがでしょうか？